### PR TITLE
fix the missing typo bring to incorrect height calculation

### DIFF
--- a/src/lib/components/IsometricMap.js
+++ b/src/lib/components/IsometricMap.js
@@ -171,7 +171,7 @@ class IsometricMap extends Component {
       "--map-width": mapWidth,
       "--map-height": mapHeight,
       "--tile-size": tileSize,
-      "--slab-suze": slabSize,
+      "--slab-size": slabSize,
       "--size-unit": sizeUnit,
       "--margin-top": margin.top,
       "--margin-bottom": margin.bottom,


### PR DESCRIPTION
Hey guys, I just found some mistyping on the css-variable name. This leading to the height calculation bug. Could you please help me review and merge if you think it's look good to you. 